### PR TITLE
fix return exception message

### DIFF
--- a/src/stomp.orig.js
+++ b/src/stomp.orig.js
@@ -118,8 +118,12 @@
       ws = new Socket(url);
       ws.binaryType = "arraybuffer";
       ws.onmessage = onmessage;
-      ws.onclose   = function() {
+      ws.onclose   = function(evt) {
         var msg = "Whoops! Lost connection to " + url;
+        if(evt){
+          //evt is a object,it contains exception code and reason
+          msg=evt.reason;
+        }
         debug(msg);
           if (errorCallback) {
             errorCallback(msg);


### PR DESCRIPTION
There are many reasons why the connection is disconnected.So we must return the exception message correctly.This helps the user to analyze the reason and make changes.For example,I use it with SockJS,when it's be called, The argument evt is a SimpleEvent Obejct(code、reason、type、wasClean).The reason attribute is the real reason why the connection is disconnected.
